### PR TITLE
Avoid boot-repair hanging by disabling interactive prompts in parted

### DIFF
--- a/usr/share/boot-sav/bs-common.sh
+++ b/usr/share/boot-sav/bs-common.sh
@@ -56,7 +56,7 @@ local lvline line temp part disk raidset temp2
 
 #Add standard partitions
 while read line; do
-	temp=${line%%:*} 
+	temp=${line%%:*}
 	part=${temp#*dev/} 	#e.g. "sda12" or "mapper/isw_decghhaeb_Volume0p2" or "/mapper/isw_bcbggbcebj_ARRAY4" or "/dev/mapper/vg_adamant-lv_root"
 	disk=""
 	echo "[debug]part : $part"	#Add "squashfs" ?   #sr1 : http://paste.ubuntu.com/996225
@@ -327,11 +327,11 @@ for ((i=1;i<=NBOFDISKS;i++)); do
 	a=$(cat "${TMP_FOLDER_TO_BE_CLEARED}/sort" | sort -g -r | tail -1 )  #sort the file in the increasing order
 	[[ "$(grep "^[0-9]\+$" <<< $a )" ]] && SECTORS_BEFORE_PART[$i]="$a" || SECTORS_BEFORE_PART[$i]="1" # Save minimum 1 sector (the MBR)
 	rm -f ${TMP_FOLDER_TO_BE_CLEARED}/sort
-	# a=$(LANGUAGE=C LC_ALL=C fdisk -l /dev/$disk | grep "sectors of"); b=${a##*= }; c=${b% *}; 
+	# a=$(LANGUAGE=C LC_ALL=C fdisk -l /dev/$disk | grep "sectors of"); b=${a##*= }; c=${b% *};
 	# echo "$c" > ${TMP_FOLDER_TO_BE_CLEARED}/sort   #Other way to calculate
 	echo "$(stat -c %B /dev/${LISTOFDISKS[$i]})" > ${TMP_FOLDER_TO_BE_CLEARED}/sort
 	echo 512 >> ${TMP_FOLDER_TO_BE_CLEARED}/sort # Save minimum 512 bytes/sector (in case there is a problem with stat)
-	BYTES_PER_SECTOR[$i]=$(cat "${TMP_FOLDER_TO_BE_CLEARED}/sort" | sort -g | tail -1 ) 
+	BYTES_PER_SECTOR[$i]=$(cat "${TMP_FOLDER_TO_BE_CLEARED}/sort" | sort -g | tail -1 )
 	rm -f ${TMP_FOLDER_TO_BE_CLEARED}/sort
 	BYTES_BEFORE_PART[$i]=$((${SECTORS_BEFORE_PART[$i]}*${BYTES_PER_SECTOR[$i]}))
 	echo "[debug] BYTES_BEFORE_PART[$i] (${LISTOFDISKS[$i]}) = ${SECTORS_BEFORE_PART[$i]} sectors * ${BYTES_PER_SECTOR[$i]} bytes = ${BYTES_BEFORE_PART[$i]} bytes."
@@ -417,7 +417,7 @@ $DASH fdisk -l:
 $(fdisk -l)
 
 "
-for ((i=1;i<=TOTAL_QUANTITY_OF_OS;i++)); do  
+for ((i=1;i<=TOTAL_QUANTITY_OF_OS;i++)); do
 	if [[ "${OS_PARTITION[$i]}" != "$OS_TO_DELETE_PARTITION" ]] \
 	&& [[ "${LOG_PATH[$i]}/$DATE$APPNAME$SECOND" != "$LOGREP" ]] \
 	&& [[ ! "${RECOVORHID[$i]}" ]] && [[ ! "${SEPWINBOOTOS[$i]}" ]] && [[ ! "${READONLY[$i]}" ]]; then
@@ -492,7 +492,7 @@ if [[ "$OSPROBER" ]];then
 
 	##CHECK THE TYPE OF EACH OS
 	for ((i=1;i<=TOTAL_QUANTITY_OF_OS;i++)); do
-		if [[ "$(grep -i linux <<< ${OS_COMPLETE_NAME[$i]} )" ]]; then 
+		if [[ "$(grep -i linux <<< ${OS_COMPLETE_NAME[$i]} )" ]]; then
 			(( QUANTITY_OF_DETECTED_LINUX += 1 ))
 			TYPE[$i]=linux
 		elif [[ "$(grep -i windows <<< ${OS_COMPLETE_NAME[$i]} )" ]];then
@@ -557,7 +557,7 @@ for ((m=1;m<=QUANTITY_OF_DISKS;m++)); do
 		if [[ "${OS_DISK[$i]}" = "${DISK[$m]}" ]];then
 			(( QTY_OF_OS_ON_DISK[$m] += 1 ))
 			OS_PARTITION_ON_DISK[${QTY_OF_OS_ON_DISK[$m]}]="${OS_PARTITION[$i]}"
-			TYPE_ON_DISK[${QTY_OF_OS_ON_DISK[$m]}]="${TYPE[$i]}" 
+			TYPE_ON_DISK[${QTY_OF_OS_ON_DISK[$m]}]="${TYPE[$i]}"
 			LOG_PATH_ON_DISK[${QTY_OF_OS_ON_DISK[$m]}]="${LOG_PATH[$i]}"
 			NEWMBR_PATH_ON_DISK[${QTY_OF_OS_ON_DISK[$m]}]="${MBR_PATH[$i]}"
 			OLDMBR_PATH_ON_DISK[${QTY_OF_OS_ON_DISK[$m]}]=$(sed "s/${PACK_NAME}/clean/g" <<< "${MBR_PATH[$i]}")
@@ -604,7 +604,7 @@ for i in $(dir "${MBR_PATH_ON_DISK[$k]}" ); do
 	# First backup system
 	if [[ "$i" =~ mbr- ]] && [[ ! -f "$LOGREP/${DISK[$m]}/$i" ]];then
 		check_if_tmp_mbr_is_grub_type "${MBR_PATH_ON_DISK[$k]}/$i"
-		if [[ "$MBRCONTAINSGRUB" = false ]]; then 
+		if [[ "$MBRCONTAINSGRUB" = false ]]; then
 			mkdir -p "$LOGREP/${DISK[$m]}"
 			cp "${MBR_PATH_ON_DISK[$k]}/$i" "$LOGREP/${DISK[$m]}"
 			echo "** ${MBR_PATH_ON_DISK[$k]}/$i has been saved into $LOGREP/${DISK[$m]}"

--- a/usr/share/boot-sav/bs-common.sh
+++ b/usr/share/boot-sav/bs-common.sh
@@ -20,8 +20,8 @@ echo "[debug]Delete the content of TMP_FOLDER_TO_BE_CLEARED and put os-prober in
 OSPROBER=$(os-prober)
 blkid -g			#Update the UUID cache
 BLKID=$(blkid)
-PARTEDL="$(LANGUAGE=C LC_ALL=C parted -l)"
-PARTEDLM="$(LANGUAGE=C LC_ALL=C parted -lm)" #ex with null -l but -lm ok http://paste.ubuntu.com/1206434
+PARTEDL="$(LANGUAGE=C LC_ALL=C parted --script -l)"
+PARTEDLM="$(LANGUAGE=C LC_ALL=C parted --script -lm)" #ex with null -l but -lm ok http://paste.ubuntu.com/1206434
 }
 
 ######################################### check_blkid_partitions ###############################

--- a/usr/share/boot-sav/gui-actions.sh
+++ b/usr/share/boot-sav/gui-actions.sh
@@ -58,7 +58,7 @@ if [[ -f "$LOGREP/$2/$1" ]];then	#Security
 	echo "Restore the Clean-Ubiquity MBR backup $1 into the MBR of disk $2"
 	mv "$LOGREP/$2/current_mbr.img" "$LOGREP/$2/mbr_before_restoration.img"
 	dd if="$LOGREP/$2/$1" of=/dev/$2 bs=446 count=1 #Stops before the partition table
-else 
+else
 	echo "Error : $LOGREP/$2/$1 does not exist"
 	zenity --error --text="Error : MBR backup $LOGREP/$2/$1 does not exist. MBR could not be restored."
 fi
@@ -280,7 +280,7 @@ multi(0)disk(0)rdisk(${tempdisk})partition(${tempnum})\WINDOWS=\"Windows\" /noex
 					if [[ "$(ls ${BLKIDMNT_POINT[$j]}/ | grep -ix $file )" ]];then
 						filetocopy="$(ls ${BLKIDMNT_POINT[$j]} | grep -ix $file )"
 						cp "${BLKIDMNT_POINT[$j]}/$filetocopy" "${BLKIDMNT_POINT[$i]}/$filetocopy"
-						echo "Copied $filetocopy from ${LISTOFPARTITIONS[$j]} to ${LISTOFPARTITIONS[$i]}"			
+						echo "Copied $filetocopy from ${LISTOFPARTITIONS[$j]} to ${LISTOFPARTITIONS[$i]}"
 						break
 					fi
 				done
@@ -388,7 +388,7 @@ if [[ ! -f "$LOGREP/${GRUBSTAGEONE}/before_wiping.img" ]];then #works: http://pa
 	if [[ ! -f "$LOGREP/${GRUBSTAGEONE}/before_wiping.img" ]];then
 		echo "Could not backup, wipe cancelled."
 		ERROR=yes
-	else	
+	else
 		echo "WIPE $GRUBSTAGEONE : ${SECTORS_TO_WIPE} sectors * ${BYTES_PER_SECTOR} bytes"
 		if [[ "$SECTORS_TO_WIPE" -gt 0 ]] && [[ "$SECTORS_TO_WIPE" -le 2048 ]] && [[ "$BYTES_PER_SECTOR" -ge 512 ]] \
 		&& [[ "$BYTES_PER_SECTOR" -le 1024 ]];then

--- a/usr/share/boot-sav/gui-actions.sh
+++ b/usr/share/boot-sav/gui-actions.sh
@@ -218,8 +218,8 @@ local PARTTOBEFLAGGED=$1 temp PRIMARYNUM DISKTOFLAG r
 temp=${LISTOFPARTITIONS[$PARTTOBEFLAGGED]}	#sdXY
 PRIMARYNUM="${temp##*[a-z]}"				#Y (1~4) of sdXY
 DISKTOFLAG="${DISK_PART[$PARTTOBEFLAGGED]}" #sdX
-echo "parted /dev/$DISKTOFLAG set $PRIMARYNUM boot on"
-parted /dev/$DISKTOFLAG set $PRIMARYNUM boot on
+echo "parted --script /dev/$DISKTOFLAG set $PRIMARYNUM boot on"
+parted --script /dev/$DISKTOFLAG set $PRIMARYNUM boot on
 FDISKL="$(LANGUAGE=C LC_ALL=C sudo fdisk -l)"
 for r in 1 2 3 4;do #http://paste.ubuntu.com/1111263
 	if [[ "$(echo "$FDISKL" | grep '*' | grep "dev/${DISKTOFLAG}$r" )" ]] && [[ "$r" != "$PRIMARYNUM" ]];then

--- a/usr/share/boot-sav/gui-scan.sh
+++ b/usr/share/boot-sav/gui-scan.sh
@@ -212,7 +212,7 @@ $DASH ${temp#*boot-sav/} :"
 	for gg in /usr/sbin/ /usr/bin/ /sbin/ /bin/;do
 		[[ -f "${BLKIDMNT_POINT[$i]}${gg}grub-setup" ]] && GRUBSETUP_OF_PART[$i]=grub-setup
 	done
-	
+
 	GRUBOK_OF_PART[$i]=""
 	if [[ "${GRUBVER[$i]}" = grub1 ]] || [[ "${UPDATEGRUB_OF_PART[$i]}" != no-update-grub ]] \
 	&& [[ "${GRUBTYPE_OF_PART[$i]}" != nogrubinstall ]];then
@@ -220,7 +220,7 @@ $DASH ${temp#*boot-sav/} :"
 		(( QTY_OF_PART_WITH_GRUB += 1 ))
 		LIST_OF_PART_WITH_GRUB[$QTY_OF_PART_WITH_GRUB]="$i"
 	fi
-	
+
 	if [[ -f "${BLKIDMNT_POINT[$i]}/usr/bin/apt-get" ]] || [[ -f "${BLKIDMNT_POINT[$i]}/usr/bin/yum" ]] \
 	|| [[ -f "${BLKIDMNT_POINT[$i]}/usr/bin/zypper" ]] || [[ -f "${BLKIDMNT_POINT[$i]}/usr/bin/pacman" ]] \
 	|| [[ -f "${BLKIDMNT_POINT[$i]}/bin/apt-get" ]] || [[ -f "${BLKIDMNT_POINT[$i]}/bin/yum" ]] \
@@ -330,7 +330,7 @@ $(ls "${BLKIDMNT_POINT[$i]}/boot")
 	else
 		SEPARATE_USR_PART[$i]=not-sep-usr
 	fi
-	
+
 
 	if [[ -f "${BLKIDMNT_POINT[$i]}/etc/fstab" ]];then
 		if [[ "$(cat "${BLKIDMNT_POINT[$i]}/etc/fstab" | grep /boot/efi | grep -v '#' )" ]];then
@@ -434,7 +434,7 @@ $(ls "${BLKIDMNT_POINT[$i]}/boot")
 		BOOT_IN_FSTAB_OF_PART[$i]=part-has-no-fstab
 		USR_IN_FSTAB_OF_PART[$i]=part-has-no-fstab
 	fi
-	
+
 	PART_WITH_SEPARATEBOOT[$i]=not-sepboot
 	if [[ "${PART_WITH_OS[$i]}" != no-os ]];then
 		PART_WITH_SEPARATEBOOT[$i]=not-sepboot
@@ -489,7 +489,7 @@ $temp
 		(( QTY_WINBOOTTOREPAIR += 1 ))
 		WINSETOREPAIR[$i]=yes
 	fi
-	
+
 	#TODO use parted when GPT http://paste.ubuntu.com/1178478
 	FARBIOS[$i]=not-far
 	temp="$(echo "$FDISKL" | grep "${LISTOFPARTITIONS[$i]} " )"
@@ -526,7 +526,7 @@ $temp
 			fi
 		done < <(echo "$PARTEDLM")
 	fi
-	
+
 	if [[ -f "${BLKIDMNT_POINT[$i]}/etc/mdadm/mdadm.conf" ]];then
 		echo "
 $DASH ${LISTOFPARTITIONS[$i]}/etc/mdadm/mdadm.conf :
@@ -547,7 +547,7 @@ $(cat "${BLKIDMNT_POINT[$i]}"/proc/mdstat)
 	if [[ -d "${BLKIDMNT_POINT[$i]}/casper" ]] || [[ -d "${BLKIDMNT_POINT[$i]}/preseed" ]] \
 	|| [[ -f "${BLKIDMNT_POINT[$i]}/autorun.inf" ]] && [[ "${USBDISK[${DISKNB_PART[$i]}]}" = usb-disk ]];then
 		ddd="${DISKNB_PART[$i]}" #eg http://ubuntuforums.org/showpost.php?p=12264795&postcount=574
-		USBDISK[$ddd]=liveusb		
+		USBDISK[$ddd]=liveusb
 	fi
 
 	WINEFI[$i]=""
@@ -660,7 +660,7 @@ for ((d=1;d<=NBOFDISKS;d++)); do
 	else
 		ReadEFIdos
 	fi
-	
+
 done
 }
 

--- a/usr/share/boot-sav/gui-scan.sh
+++ b/usr/share/boot-sav/gui-scan.sh
@@ -49,11 +49,11 @@ for ((d=1;d<=NBOFDISKS;d++)); do
 done
 echo "
 
-$DASH parted -l:
+$DASH parted --script -l:
 
 $PARTEDL
 
-$DASH parted -lm:
+$DASH parted --script -lm:
 
 $PARTEDLM
 "


### PR DESCRIPTION
Fixes boot-repair hanging forever when scanning partitions causes parted to return an interactive prompt. 

eg. http://ubuntuforums.org/showthread.php?t=2098014
