### PR TITLE
Support pkexec in addition to gksudo, et al

### DIFF
--- a/usr/share/boot-sav/gui-g2slaunch.sh
+++ b/usr/share/boot-sav/gui-g2slaunch.sh
@@ -39,6 +39,8 @@ cd /usr/share/$PACK_NAME
 
 # Ask root privileges
 if [[ $EUID -ne 0 ]];then
+	if hash pkexec;then
+		pkexec $APPNAME
 	if hash gksudo;then
 		gksudo $APPNAME  #gksu and su dont work in Kubuntu
 	elif hash gksu;then


### PR DESCRIPTION
This is the preferred mechanism; gksu(do) is deprecated.
